### PR TITLE
Add message queue and raw subscribers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode

--- a/src/gitops_connector.py
+++ b/src/gitops_connector.py
@@ -1,9 +1,12 @@
 import logging
+from queue import PriorityQueue
+
 from operators.gitops_operator_factory import GitopsOperatorFactory
 from repositories.git_repository_factory import GitRepositoryFactory
+from repositories.raw_subscriber import RawSubscriberFactory
 from orchestrators.cicd_orchestrator_factory import CicdOrchestratorFactory
 
-
+# Instance is shared across threads.
 class GitopsConnector:
 
     def __init__(self):
@@ -11,31 +14,56 @@ class GitopsConnector:
         self._git_repository = GitRepositoryFactory.new_git_repository()
         self._cicd_orchestrator = CicdOrchestratorFactory.new_cicd_orchestrator(self._git_repository)
 
+        # Subscribers that take unprocessed JSON, forwarded from the notifications
+        self._raw_subscribers = RawSubscriberFactory.new_raw_subscribers()
 
-    def process_gitops_phase(self, phase_data):
+        # Commit status notification queue
+        self._global_message_queue = PriorityQueue()
+
+    def process_gitops_phase(self, phase_data, req_time):
         if self._gitops_operator.is_supported_message(phase_data):
-            self._post_commit_statuses(phase_data)
+            self._queue_commit_statuses(phase_data, req_time)
             self._notify_orchestrator(phase_data)
         else:
             logging.debug(f'Message is not supported: {phase_data}')
 
-    def _post_commit_statuses(self, phase_data):
+    def _queue_commit_statuses(self, phase_data, req_time):
         commit_statuses = self._gitops_operator.extract_commit_statuses(phase_data)
         for commit_status in commit_statuses:
-            self._git_repository.post_commit_status(commit_status)
-        
+            self._global_message_queue.put(item=(req_time, commit_status))
+
     def _notify_orchestrator(self, phase_data):
         is_finished, is_successful = self._gitops_operator.is_finished(phase_data)
         if is_finished:
             commit_id = self._gitops_operator.get_commit_id(phase_data)
             self._cicd_orchestrator.notify_on_deployment_completion(commit_id, is_successful)
 
+    # Entrypoint for the periodic task to search for abandoned PRs linked to
+    # agentless tasks.
     def notify_abandoned_pr_tasks(self):
         try:
             self._cicd_orchestrator.notify_abandoned_pr_tasks()
         except Exception as e:
             logging.error(f'Failed to notify abandoned PRs: {e}')
 
+    # Entrypoint for the commit status thread.
+    # The thread waits for items in the priority queue and sends the messages
+    # in the order of the request received time.
+    def drain_commit_status_queue(self):
+        while (True):
+            # Blocking get
+            commit_status = self._global_message_queue.get()
+
+            if not commit_status:
+                break
+
+            # Queue entry is (received time, commit_status)
+            commit_status = commit_status[1]
+
+            self._git_repository.post_commit_status(commit_status)
+
+            for subscriber in self._raw_subscribers:
+                subscriber.post_commit_status(commit_status)
 
 if __name__ == "__main__":
-     git_ops_connector = GitopsConnector()  
+     git_ops_connector = GitopsConnector()

--- a/src/gitops_connector.py
+++ b/src/gitops_connector.py
@@ -6,6 +6,7 @@ from repositories.git_repository_factory import GitRepositoryFactory
 from repositories.raw_subscriber import RawSubscriberFactory
 from orchestrators.cicd_orchestrator_factory import CicdOrchestratorFactory
 
+
 # Instance is shared across threads.
 class GitopsConnector:
 
@@ -64,6 +65,7 @@ class GitopsConnector:
 
             for subscriber in self._raw_subscribers:
                 subscriber.post_commit_status(commit_status)
+
 
 if __name__ == "__main__":
     git_ops_connector = GitopsConnector()

--- a/src/gitops_event_handler.py
+++ b/src/gitops_event_handler.py
@@ -42,11 +42,13 @@ def pr_polling_thread_worker():
     gitops_connector.notify_abandoned_pr_tasks()
     logging.info(f'Finished PR cleanup, sleeping for {PR_CLEANUP_INTERVAL} seconds...')
 
+
 # Git status queue drain task
 def init_commit_status_thread():
     logging.info("Starting commit status thread")
     status_thread = Thread(target=gitops_connector.drain_commit_status_queue)
     status_thread.run()
+
 
 def interrupt():
     if not DISABLE_POLLING_PR_TASK:

--- a/src/gitops_event_handler.py
+++ b/src/gitops_event_handler.py
@@ -47,7 +47,7 @@ def pr_polling_thread_worker():
 def init_commit_status_thread():
     logging.info("Starting commit status thread")
     status_thread = Thread(target=gitops_connector.drain_commit_status_queue)
-    status_thread.run()
+    status_thread.start()
 
 
 def interrupt():

--- a/src/gitops_event_handler.py
+++ b/src/gitops_event_handler.py
@@ -3,6 +3,8 @@ import logging
 from timeloop import Timeloop
 from datetime import timedelta
 import atexit
+import time
+from threading import Thread
 from gitops_connector import GitopsConnector
 
 # Time in seconds between background PR cleanup jobs
@@ -17,11 +19,14 @@ gitops_connector = GitopsConnector()
 
 @application.route("/gitopsphase", methods=['POST'])
 def gitopsphase():
+    # Use per process timer to stash the time we got the request
+    req_time = time.monotonic_ns()
+
     payload = request.get_json()
 
     logging.debug(f'GitOps phase: {payload}')
 
-    gitops_connector.process_gitops_phase(payload)
+    gitops_connector.process_gitops_phase(payload, req_time)
 
     return f'GitOps phase: {payload}', 200
 
@@ -33,6 +38,12 @@ def pr_polling_thread_worker():
     gitops_connector.notify_abandoned_pr_tasks()
     logging.info(f'Finished PR cleanup, sleeping for {PR_CLEANUP_INTERVAL} seconds...')
 
+# Git status queue drain task
+def init_commit_status_thread():
+    logging.info("Starting commit status thread")
+    status_thread = Thread(target=gitops_connector.drain_commit_status_queue)
+    status_thread.run()
+
 def interrupt():
     if not DISABLE_POLLING_PR_TASK:
         cleanup_task.stop()
@@ -40,6 +51,7 @@ def interrupt():
 
 if not DISABLE_POLLING_PR_TASK:
     cleanup_task.start()
+    init_commit_status_thread()
     atexit.register(interrupt)
 
 if __name__ == "__main__":

--- a/src/operators/git_commit_status.py
+++ b/src/operators/git_commit_status.py
@@ -9,3 +9,7 @@ class GitCommitStatus:
     callback_url: str
     gitops_operator: str
     genre: str
+
+    def __lt__(self, other):
+        # Status messages need to come last.
+        return self.genre != "Status"

--- a/src/repositories/raw_subscriber.py
+++ b/src/repositories/raw_subscriber.py
@@ -23,11 +23,15 @@ class RawSubscriberFactory:
     def new_raw_subscribers() -> list[RawSubscriber]:
         subscribers = []
 
+        logging.debug("Adding configured subscribers...")
+
         # TODO(tcare): Dynamically pick up subscribers via CRD or similar
         # Currently we only have one subscriber
         endpoint = os.getenv("RAW_SUBSCRIBER_ENDPOINT")
         if endpoint:
             subscriber = RawSubscriber(endpoint)
             subscribers.append(subscriber)
+
+        logging.debug(f'{len(subscribers)} subscribers added.')
 
         return subscribers

--- a/src/repositories/raw_subscriber.py
+++ b/src/repositories/raw_subscriber.py
@@ -5,6 +5,7 @@ import logging
 import os
 import requests
 
+
 # An endpoint that handles unprocessed JSON forwarded from notifications.
 class RawSubscriber:
     def __init__(self, url_endpoint):
@@ -14,6 +15,7 @@ class RawSubscriber:
         json_data = dataclasses.asdict(commit_status[1])
         logging.debug("Sending raw json to subscriber: " + json.dumps(json_data))
         response = requests.post(url=self._url_endpoint, json=json_data)
+        response.raise_for_status()
 
 
 class RawSubscriberFactory:

--- a/src/repositories/raw_subscriber.py
+++ b/src/repositories/raw_subscriber.py
@@ -1,0 +1,27 @@
+
+import dataclasses
+import json
+import logging
+import os
+import requests
+
+# An endpoint that handles unprocessed JSON forwarded from notifications.
+class RawSubscriber:
+    def __init__(self, url_endpoint):
+        self._url_endpoint = url_endpoint
+
+    def post_commit_status(self, commit_status):
+        json_data = dataclasses.asdict(commit_status[1])
+        logging.debug("Sending raw json to subscriber: " + json.dumps(json_data))
+        response = requests.post(url=self._url_endpoint, json=json_data)
+
+class RawSubscriberFactory:
+    @staticmethod
+    def new_raw_subscribers() -> list[RawSubscriber]:
+        # TODO(tcare): Dynamically pick up subscribers via CRD or similar
+        # Currently we only have one subscriber
+        subscribers = []
+        subscriber = RawSubscriber(os.getenv("SPEKTATE_ENDPOINT"))
+        subscribers.append(subscriber)
+
+        return subscribers

--- a/src/repositories/raw_subscriber.py
+++ b/src/repositories/raw_subscriber.py
@@ -12,7 +12,7 @@ class RawSubscriber:
         self._url_endpoint = url_endpoint
 
     def post_commit_status(self, commit_status):
-        json_data = dataclasses.asdict(commit_status[1])
+        json_data = dataclasses.asdict(commit_status)
         logging.debug("Sending raw json to subscriber: " + json.dumps(json_data))
         response = requests.post(url=self._url_endpoint, json=json_data)
         response.raise_for_status()

--- a/src/repositories/raw_subscriber.py
+++ b/src/repositories/raw_subscriber.py
@@ -15,13 +15,17 @@ class RawSubscriber:
         logging.debug("Sending raw json to subscriber: " + json.dumps(json_data))
         response = requests.post(url=self._url_endpoint, json=json_data)
 
+
 class RawSubscriberFactory:
     @staticmethod
     def new_raw_subscribers() -> list[RawSubscriber]:
+        subscribers = []
+
         # TODO(tcare): Dynamically pick up subscribers via CRD or similar
         # Currently we only have one subscriber
-        subscribers = []
-        subscriber = RawSubscriber(os.getenv("SPEKTATE_ENDPOINT"))
-        subscribers.append(subscriber)
+        endpoint = os.getenv("RAW_SUBSCRIBER_ENDPOINT")
+        if endpoint:
+            subscriber = RawSubscriber(endpoint)
+            subscribers.append(subscriber)
 
         return subscribers


### PR DESCRIPTION
- Add priority queue for incoming requests sorted by request received time. This helps mitigate delays in processing messages that end up sending status messages in the wrong order.
- Added thread to drain the priority queue.
- Added raw subscriber list for endpoints that don't need any JSON transformation. These are sent in addition to the GitRepository.