### PR TITLE
Add support for nodeSelector in deployment

### DIFF
--- a/manifests/helm/templates/deployment.yaml
+++ b/manifests/helm/templates/deployment.yaml
@@ -137,3 +137,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/manifests/helm/values.yaml
+++ b/manifests/helm/values.yaml
@@ -26,3 +26,7 @@ gitHubOrgUrl: $GITHUB_ORG_URL
 #     operator: Equal
 #     value: spot
 #     effect: NoSchedule
+
+# Optional node selector rules
+# nodeSelector:
+#   kubernetes.io/os: linux


### PR DESCRIPTION
Add support for `nodeSelector` attribute. This is useful for hybrid clusters with mixed Windows/Linux nodes to specify which nodes to schedule the pods so that the connector pods don't get scheduled on Windows nodes.