### PR TITLE
Support for more complex message from manifest commit message to dispatch event. (To handle flux image automation where list images is set by default). Fix errors with deploys being marked failed prematurely. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ payload = {
     'event_type': "sync-success",
     'client_payload': {'sha': {commmit_id},                //Commit Id in source repo that started the CI/CD process 
                       'runid': {github_workflow_run_id}    //GitHub Actions Workflow RunId that produced artifacts (e.g. Docker Image Tags)
+                      'commitmessage': {commit_message}    //Full commit message from the commit that updated the manifests. Used to pass metadata for tying back to the source repo commits if there are multiple. 
     }
 ```
 

--- a/src/operators/flux_gitops_operator.py
+++ b/src/operators/flux_gitops_operator.py
@@ -128,7 +128,8 @@ class FluxGitopsOperator(GitopsOperatorInterface):
         logging.debug(f'Kind: {kind}')
 
         reason = phase_data['reason']
-        logging.debug(f'Reason: {reason}')    
+        logging.debug(f'Reason: {reason}')
+
         return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact')
 
     def _get_message_kind(self, phase_data) -> str:

--- a/src/operators/flux_gitops_operator.py
+++ b/src/operators/flux_gitops_operator.py
@@ -129,11 +129,17 @@ class FluxGitopsOperator(GitopsOperatorInterface):
 
         reason = phase_data['reason']
         logging.debug(f'Reason: {reason}')
+        
+        commitstatus = self._get_message_commit_status(phase_data)
+        logging.debug(f'CommitStatus: {commitstatus}')
 
-        return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact')
+        return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact' and commitstatus == None)
 
     def _get_message_kind(self, phase_data) -> str:
         return phase_data['involvedObject']['kind']
+    
+    def _get_message_commit_status(self, phase_data) -> str:
+        return phase_data['involvedObject']['metadata'].get('commit_status')
 
     def _map_reason_to_description(self, reason, original_message):
         # Explicitly handle all statuses so we make sure we don't silently miss any.

--- a/src/operators/flux_gitops_operator.py
+++ b/src/operators/flux_gitops_operator.py
@@ -128,8 +128,7 @@ class FluxGitopsOperator(GitopsOperatorInterface):
         logging.debug(f'Kind: {kind}')
 
         reason = phase_data['reason']
-        logging.debug(f'Reason: {reason}')
-       
+        logging.debug(f'Reason: {reason}')    
         return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact')
 
     def _get_message_kind(self, phase_data) -> str:

--- a/src/operators/flux_gitops_operator.py
+++ b/src/operators/flux_gitops_operator.py
@@ -129,17 +129,11 @@ class FluxGitopsOperator(GitopsOperatorInterface):
 
         reason = phase_data['reason']
         logging.debug(f'Reason: {reason}')
-        
-        commitstatus = self._get_message_commit_status(phase_data)
-        logging.debug(f'CommitStatus: {commitstatus}')
-
-        return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact' and commitstatus == None)
+       
+        return (kind == 'Kustomization' or kind == 'GitRepository' and reason != 'NewArtifact')
 
     def _get_message_kind(self, phase_data) -> str:
         return phase_data['involvedObject']['kind']
-    
-    def _get_message_commit_status(self, phase_data) -> str:
-        return phase_data['involvedObject']['metadata'].get('commit_status')
 
     def _map_reason_to_description(self, reason, original_message):
         # Explicitly handle all statuses so we make sure we don't silently miss any.

--- a/src/orchestrators/github_cicd_orchestrator.py
+++ b/src/orchestrators/github_cicd_orchestrator.py
@@ -20,24 +20,27 @@ class GitHubCicdOrchestrator(CicdOrchestratorInterface):
 
     def notify_on_deployment_completion(self, commit_id, is_successful):
         if is_successful:
-            source_commit_id, run_id = self._get_source_commit_id_run_id(commit_id)
-            self._send_repo_dispatch_event(source_commit_id, run_id)
+            source_commit_id, run_id, commit_message = self._get_source_commit_id_run_id_commit_mesage(commit_id)
+            self._send_repo_dispatch_event(source_commit_id, run_id, commit_message)
 
     def notify_abandoned_pr_tasks(self):
         pass
 
-    def _get_source_commit_id_run_id(self, manifest_commitid):
+    def _get_source_commit_id_run_id_commit_mesage(self, manifest_commitid):
         commitMessage = self.git_repository.get_commit_message(manifest_commitid)
         commitMessageArray = commitMessage.split('/', 5)
-        runid = commitMessageArray[2]
-        commitid = commitMessageArray[3]
+        try:
+            runid = commitMessageArray[2]
+            commitid = commitMessageArray[3]
+        except  
+            pass
         logging.info(f'CommitId {commitid}')
-        return commitid, runid
+        return commitid, runid, commitMessage
 
-    def _send_repo_dispatch_event(self, commmit_id, run_id):
+    def _send_repo_dispatch_event(self, commmit_id, run_id, commit_message):
         url = f'{self.rest_api_url}/{self.gitops_repo_name}/dispatches'
         event_type = 'sync-success'
-        data = {'event_type': event_type, 'client_payload': {'sha': commmit_id, 'runid': run_id}}
+        data = {'event_type': event_type, 'client_payload': {'sha': commmit_id, 'runid': run_id, 'commitmessage': commit_message}}
         logging.info(f'Dispatch event: url {url}; data {data}')
         response = requests.post(url=url, headers=self.headers, json=data)
         # Throw appropriate exception if request failed

--- a/src/repositories/github_git_repository.py
+++ b/src/repositories/github_git_repository.py
@@ -55,7 +55,7 @@ class GitHubGitRepository(GitRepositoryInterface):
             "ReconciliationSucceeded": "success",
             "ReconciliationFailed": "failure",
             "Progressing": "pending",
-            "DependencyNotReady": "error",
+            "DependencyNotReady": "pending",
             "PruneFailed": "failure",
             "ArtifactFailed": "failure",
             "BuildFailed": "failure",


### PR DESCRIPTION
A few updates to handle using this with flux image automation, and also to resolve an issue where successful commits get marked as failed prematurely. 

1)  Add try/except around extracting the runId and commitId from the source commit message, also passing along the unparsed commit message to support cases like flux image automation where there may be multiple image updates from commits/runs batched into a single manifest commit, and where it may be difficult to add a commit message formatted for extracting a runId/commitId.

2) Changed DependencyNotReady mapping from error to pending. Once a commit status with error status is sent to github the commit itself goes into the failure status, and from there gitops-connector stop processing further messages for that commit.  DependencyNotReady can be emitted during a deployment that is ultimately successful. I also think HealthCheckFailed may have the same issues, a health check may fail as a container is initializing and then ultimately end up succeeding so we wouldn't want a single failure to cause a failed commit I don't think?


This discussion from flux maintainer suggests that DependencyNotReady just means reconciliation is in progress and not an indication of failure.
https://github.com/fluxcd/flux2/discussions/1160

Also I am unsure how to test this in my own cluster ahead of time, so just wanted to call out that these changes haven't been tested live but I believe they are simple enough.