### PR TITLE
Fix #67 - Update Flask version requirement.

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.0
+Flask==2.3
 gunicorn==20.0.4
 requests
 timeloop


### PR DESCRIPTION
Update the flask version to 2.3 which replaces the werkzeug.urls reference with an equivalent from the Python library. This fix allows the application to startup properly.

I tested with Helm chart 1.2.1 by updating the values file to include an image name and tag pointing at a registry I had write access to.